### PR TITLE
Fix order of values

### DIFF
--- a/src/formatjson.js
+++ b/src/formatjson.js
@@ -36,6 +36,7 @@ export const formatFloJson = (data) => {
     );
     return {
       date: format(new Date(date), "yyyy-MM-dd"),
+      ...initialExtraFields,
       "bleeding.value": isInInterval ? "2" : "",
       "bleeding.exclude": isInInterval ? "FALSE" : "",
       ...extraFields,
@@ -45,12 +46,13 @@ export const formatFloJson = (data) => {
   return jsonToCSV(parsedData);
 };
 
-const extraFields = {
+const initialExtraFields = {
   "temperature.value": "",
   "temperature.exclude": "",
   "temperature.time": "",
   "temperature.note": "",
-
+};
+const extraFields = {
   "mucus.feeling": "",
   "mucus.texture": "",
   "mucus.value": "",


### PR DESCRIPTION
To ensure the correct field order in the output CSV file, the temperature values were moved before the bleeding fields in the formatFloJson function. This was necessary because the previous order of values did not permit import. 

![drip_import_error](https://github.com/user-attachments/assets/b56ba3e7-4805-4942-8518-04d1fffae117)

A new constant, "initialExtraFields", was created for this purpose.